### PR TITLE
add beacon_node_*_light_client_data variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,11 @@ beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
 
+# Light client data
+beacon_node_light_client_data_enabled: false
+beacon_node_light_client_data_serve: false
+beacon_node_light_client_data_import: 'none'
+
 # Automatically distribute validators
 beacon_node_dist_validators_enabled: false
 beacon_node_dist_validators_name: '{{ beacon_node_network }}_deposits'

--- a/templates/launchd.plist.j2
+++ b/templates/launchd.plist.j2
@@ -59,6 +59,10 @@
 {% for pubkey in beacon_node_validator_monitor_pubkeys %}
     <string>--validator-monitor-pubkey={{ pubkey }}</string>
 {% endfor %}
+{% if beacon_node_light_client_data_enabled %}
+    <string>--serve-light-client-data={{ beacon_node_light_client_data_serve | to_json }}</string>
+    <string>--import-light-client-data={{ beacon_node_light_client_data_import }}</string>
+{% endif %}
   </array>
 
   <key>UserName</key>


### PR DESCRIPTION
To control the `--serve-light-client-data` and
`--import-light-client-data` flags.

Note: These new flags are only available on `unstable` at this time. `stable` does not support them yet.