### PR TITLE
renamed BN light client data options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,7 +79,7 @@ beacon_node_rest_port: 5052
 # Light client data
 beacon_node_light_client_data_enabled: false
 beacon_node_light_client_data_serve: false
-beacon_node_light_client_data_import: 'none'
+beacon_node_light_client_data_import_mode: 'none'
 
 # Automatically distribute validators
 beacon_node_dist_validators_enabled: false

--- a/templates/launchd.plist.j2
+++ b/templates/launchd.plist.j2
@@ -59,8 +59,8 @@
     <string>--validator-monitor-pubkey={{ pubkey }}</string>
 {% endfor %}
 {% if beacon_node_light_client_data_enabled %}
-    <string>--serve-light-client-data={{ beacon_node_light_client_data_serve | to_json }}</string>
-    <string>--import-light-client-data={{ beacon_node_light_client_data_import }}</string>
+    <string>--light-client-data-serve={{ beacon_node_light_client_data_serve | to_json }}</string>
+    <string>--light-client-data-import-mode={{ beacon_node_light_client_data_import_mode }}</string>
 {% endif %}
 {% for extra_flag in beacon_node_extra_flags %}
     <string>{{ extra_flag }}</string>


### PR DESCRIPTION
Adjusts for the new names of BN light client data config options
* `--serve-light-client-data` --> `--light-client-data-serve`
* `--import-light-client-data` --> `--light-client-data-import-mode`
