### PR TITLE
add beacon_node_light_client_data_max_periods

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,6 +80,7 @@ beacon_node_rest_port: 5052
 beacon_node_light_client_data_enabled: false
 beacon_node_light_client_data_serve: false
 beacon_node_light_client_data_import_mode: 'none'
+beacon_node_light_client_data_max_periods: -1 # -1 to use default
 
 # Automatically distribute validators
 beacon_node_dist_validators_enabled: false

--- a/templates/launchd.plist.j2
+++ b/templates/launchd.plist.j2
@@ -61,6 +61,9 @@
 {% if beacon_node_light_client_data_enabled %}
     <string>--light-client-data-serve={{ beacon_node_light_client_data_serve | to_json }}</string>
     <string>--light-client-data-import-mode={{ beacon_node_light_client_data_import_mode }}</string>
+{% if beacon_node_light_client_data_max_periods >= 0 %}
+    <string>--light-client-data-max-periods={{ beacon_node_light_client_data_max_periods }}</string>
+{% endif %}
 {% endif %}
 {% for extra_flag in beacon_node_extra_flags %}
     <string>{{ extra_flag }}</string>


### PR DESCRIPTION
Allows overriding `--light-client-data-max-periods` as introduced in
https://github.com/status-im/nimbus-eth2/pull/3799
