### PR TITLE
service: apply `--rest-max-body-size` and `--rest-max-headers-size`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,8 @@ beacon_node_metrics_port: 9200
 beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
+beacon_node_rest_max_body_size: 16384
+beacon_node_rest_max_headers_size: 128
 
 # Light client data
 beacon_node_light_client_data_enabled: false

--- a/templates/launchd.plist.j2
+++ b/templates/launchd.plist.j2
@@ -46,6 +46,8 @@
 {% if beacon_node_rest_enabled %}
     <string>--rest-address={{ beacon_node_rest_address }}</string>
     <string>--rest-port={{ beacon_node_rest_port }}</string>
+    <string>--rest-max-body-size={{ beacon_node_rest_max_body_size | mandatory }}</string>
+    <string>--rest-max-headers-size={{ beacon_node_rest_max_headers_size | mandatory }}</string>
 {% endif %}
     <string>--metrics={{ beacon_node_metrics_enabled | to_json }}</string>
 {% if beacon_node_metrics_enabled %}


### PR DESCRIPTION
Those two options are applied in `infra-role-beacon-node-linux`; do the same for macOS.